### PR TITLE
Add multi-strategy nesting and reporting

### DIFF
--- a/auto_nest.py
+++ b/auto_nest.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
 
     # --- добавляем список известных флагов, которые прокидываем в nest.exe ---
     allowed_flags = {"-v", "--verbose", "-j", "--join-segments",
-                     "--pop", "--gen", "--runs", "--polish", "--strategy"}
+                     "--pop", "--gen", "--polish", "--fill-gaps"}
 
     s_idx = sys.argv.index("-s")
     try:
@@ -24,12 +24,24 @@ if __name__ == "__main__":
         nums = []
         dxf_files = []  # список кортежей (имя, количество)
         nest_flags = [] # сюда кидаем "-v", "-j" и любые другие поддерживаемые
+        strategies = ["area"]
+        runs = 1
+        fill_gaps = False
 
         i = s_idx + 2
         while i < len(sys.argv):
             arg = sys.argv[i]
             if arg == "-i":
                 iterations = sys.argv[i + 1]
+                i += 2
+            elif arg == "--strategies":
+                strategies = sys.argv[i+1].split(',')
+                i += 2
+            elif arg == "--strategy":
+                strategies = [sys.argv[i+1]]
+                i += 2
+            elif arg == "--runs":
+                runs = int(sys.argv[i+1])
                 i += 2
             elif arg == "-n":
                 i += 1
@@ -44,7 +56,10 @@ if __name__ == "__main__":
                     i += 1
             elif arg in allowed_flags:
                 nest_flags.append(arg)
-                if arg.startswith('--') and arg not in ("-v", "--verbose", "-j", "--join-segments"):
+                if arg == "--fill-gaps":
+                    fill_gaps = True
+                    i += 1
+                elif arg.startswith('--') and arg not in ("-v", "--verbose", "-j", "--join-segments"):
                     if i + 1 < len(sys.argv):
                         nest_flags.append(sys.argv[i+1])
                         i += 2
@@ -73,7 +88,7 @@ if __name__ == "__main__":
         usage()
 
     json_files = []
-    python_exec = r"C:\Users\User\AppData\Local\Programs\Python\Python39\python.exe"
+    python_exec = sys.executable
     for dxf, repeat in dxf_files:
         json_out = os.path.splitext(dxf)[0] + ".json"
         print(f"[PY] DXF → JSON: {dxf} -> {json_out} (repeat={repeat})")
@@ -87,24 +102,62 @@ if __name__ == "__main__":
             sys.exit(1)
         json_files.append(json_out)
 
-    # Формируем команду nest.exe
     nest_binary = "nest.exe" if os.name == "nt" else "./nest"
-    nest_cmd = [nest_binary, "-s", sheet]
 
-    if iterations is not None:
-        nest_cmd += ["-i", iterations]
-    if nums:
-        nest_cmd += ["-n"] + list(map(str, nums))
+    tasks = []
+    for strat in strategies:
+        for r in range(runs):
+            out_csv = f"lay_{r}_{strat}.csv"
+            out_dxf = f"layout_{r}_{strat}.dxf"
+            cmd = [nest_binary, "-s", sheet]
+            if iterations is not None:
+                cmd += ["-i", iterations]
+            if nums:
+                cmd += ["-n"] + list(map(str, nums))
+            cmd += nest_flags
+            if fill_gaps:
+                cmd += ["--fill-gaps"]
+            cmd += ["--strategy", strat, "--run", str(r), "--dxf", out_dxf, "-o", out_csv]
+            cmd += json_files
+            tasks.append((cmd, out_csv, out_dxf, strat, r))
 
-    nest_cmd += nest_flags  # <-- передаем все поддерживаемые флаги
-    nest_cmd += ["-o", "lay.csv"] + json_files
+    from multiprocessing import Pool
+    def _run(t):
+        cmd=t[0]
+        print("[PY] RUN:", " ".join(cmd))
+        subprocess.check_call(cmd)
+        return t[1], t[2], t[3], t[4]
 
-    print("[PY] RUN:", " ".join(nest_cmd))
-    subprocess.check_call(nest_cmd)
-    print("[PY] Success!")
+    with Pool() as pool:
+        results = pool.map(_run, tasks)
+
+    # Aggregate lay.csv
+    with open('lay.csv','w') as fout:
+        header_written=False
+        for csvf, dxff, strat, r in results:
+            with open(csvf) as fin:
+                if not header_written:
+                    fout.write(fin.readline())
+                    header_written=True
+                else:
+                    fin.readline()
+                fout.writelines(fin.readlines())
+
+    # choose best by minimal waste
+    import csv
+    best = None
+    with open('lay.csv') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if best is None or float(row['waste_mm2']) < float(best['waste_mm2']):
+                best = row
+    best_dxf = f"layout_{best['run']}_{best['strategy']}.dxf"
+    if os.path.exists(best_dxf):
+        os.replace(best_dxf, 'layout.dxf')
     try:
         import pdf_report
-        pdf_report.generate_report("lay.csv", "nest_report.pdf")
+        pdf_report.generate_report('lay.csv', 'nest_report.pdf', 'layout.dxf')
         print("[PY] PDF saved to nest_report.pdf")
     except Exception as e:
         print("[PY] PDF generation failed", e)
+    print("[PY] Done")

--- a/pdf_report.py
+++ b/pdf_report.py
@@ -1,28 +1,69 @@
 import csv
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
+from reportlab.lib.utils import ImageReader
+import matplotlib.pyplot as plt
+import ezdxf
+import io
 
-def generate_report(csv_file, pdf_file):
+def _plot_layout(dxf_file, fill, waste):
+    doc = ezdxf.readfile(dxf_file)
+    msp = doc.modelspace()
+    fig, ax = plt.subplots()
+    for e in msp:
+        if e.dxftype() == 'LWPOLYLINE':
+            pts = [(p[0], p[1]) for p in e.get_points('xy')]
+            if len(pts) < 2:
+                continue
+            xs, ys = zip(*pts)
+            ax.plot(xs, ys)
+    ax.set_aspect('equal')
+    ax.invert_yaxis()
+    ax.set_title(f'Fill {fill:.1f}%  Waste {waste:.1f}mm2')
+    buf = io.BytesIO()
+    fig.savefig(buf, format='png')
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+def generate_report(csv_file, pdf_file, dxf_file=None):
     rows = []
     with open(csv_file) as f:
         reader = csv.DictReader(f)
         rows = list(reader)
     c = canvas.Canvas(pdf_file, pagesize=A4)
+
+    # Summary table
     y = A4[1] - 40
     c.drawString(40, y, "Nesting Report")
     y -= 20
-    if rows:
-        fill = float(rows[0].get('fill_pct',0))
-        waste = float(rows[0].get('waste_mm2',0))
-        c.drawString(40, y, f"Fill: {fill:.2f}%  Waste: {waste:.2f} mm2")
-        y -= 20
+    summary = {}
     for r in rows:
-        txt = f"run {r['run']} part {r['part']} x={r['x_mm']} y={r['y_mm']} angle={r['angle']}"
-        c.drawString(40, y, txt)
+        k = (r['run'], r['strategy'])
+        if k not in summary:
+            summary[k] = r
+    c.drawString(40, y, "Run  Strategy  Fill%  Waste")
+    y -= 15
+    best = None
+    for k, r in sorted(summary.items()):
+        fill = float(r.get('fill_pct',0))
+        waste = float(r.get('waste_mm2',0))
+        c.drawString(40, y, f"{r['run']}    {r['strategy']}    {fill:.1f}    {waste:.1f}")
+        if best is None or waste < float(best.get('waste_mm2',1e9)):
+            best = r
         y -= 12
-        if y < 40:
+        if y < 60:
             c.showPage()
             y = A4[1] - 40
+
+    # Layout page
+    if dxf_file:
+        buf = _plot_layout(dxf_file, float(best.get('fill_pct',0)), float(best.get('waste_mm2',0)))
+        img = ImageReader(buf)
+        c.showPage()
+        c.drawImage(img, 40, 80, width=A4[0]-80, height=A4[1]-160)
+        buf.close()
+
     c.save()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extend CLI and algorithm to handle run index, DXF output and optional gap fill
- improve local search with orientation swaps and dynamic step
- add gap nesting stage
- enable multiprocessing multi-strategy runs in `auto_nest.py`
- enhance PDF report with preview using matplotlib

## Testing
- `python3 -m py_compile auto_nest.py pdf_report.py`
- `g++ -std=c++17 -O2 -pthread -Iclipper3 -I. -c nesting_algorithm.cpp -o /tmp/nest.o`
- `g++ -std=c++17 -O2 -pthread -Iclipper3 -I. nesting_algorithm.cpp clipper3/src/clipper.engine.cpp clipper3/src/clipper.offset.cpp clipper3/src/clipper.rectclip.cpp -o nest`


------
https://chatgpt.com/codex/tasks/task_e_6884c77baf40832a8effd52680098e3d