### PR TITLE
Refactor geometry helpers and expand tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,16 @@ add_library(clipper3
     clipper3/src/clipper.rectclip.cpp
 )
 target_include_directories(clipper3 PUBLIC clipper3)
+add_library(geometry geometry.cpp)
+target_include_directories(geometry PUBLIC . clipper3)
+target_link_libraries(geometry PUBLIC clipper3)
+
 add_executable(nest
     nesting_algorithm.cpp
 )
 target_include_directories(nest PRIVATE . clipper3)
-target_link_libraries(nest PRIVATE clipper3 TBB::tbb)
+target_link_libraries(nest PRIVATE geometry TBB::tbb)
 
 add_executable(test_overlap tests/test_overlap.cpp)
 target_include_directories(test_overlap PRIVATE . clipper3)
-target_link_libraries(test_overlap PRIVATE clipper3 TBB::tbb)
+target_link_libraries(test_overlap PRIVATE geometry TBB::tbb)

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -1,0 +1,26 @@
+#include "geometry.h"
+
+double gKerf = 0.0;
+double gGap = 0.0;
+static constexpr double SCALE = 1e4;
+
+Paths64 movePaths(const Paths64& src, int64_t dx, int64_t dy){
+    Paths64 out; out.reserve(src.size());
+    for(const auto& path: src){
+        Path64 p; p.reserve(path.size());
+        for(auto pt: path) p.push_back({pt.x + dx, pt.y + dy});
+        out.push_back(std::move(p));
+    }
+    return out;
+}
+
+bool overlap(const Paths64& a, const Paths64& b) {
+    double delta = (gKerf * 0.5 + gGap) * SCALE;
+    Paths64 ea = InflatePaths(a, delta, JoinType::Miter, EndType::Polygon);
+    Paths64 eb = InflatePaths(b, delta, JoinType::Miter, EndType::Polygon);
+    Paths64 ua = Union(ea, FillRule::NonZero);
+    Paths64 ub = Union(eb, FillRule::NonZero);
+    Paths64 isect = Intersect(ua, ub, FillRule::NonZero);
+    return std::abs(Area(isect)) > 0.0;
+}
+

--- a/geometry.h
+++ b/geometry.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "clipper3/clipper.h"
+using namespace Clipper2Lib;
+
+extern double gKerf;
+extern double gGap;
+
+Paths64 movePaths(const Paths64& src, int64_t dx, int64_t dy);
+bool overlap(const Paths64& a, const Paths64& b);
+

--- a/nesting_algorithm.cpp
+++ b/nesting_algorithm.cpp
@@ -47,8 +47,8 @@
 #include <json.hpp>
 double gUnit = 1.0;
 bool gVerbose = false;
-double gKerf = 0.0;
-double gGap = 0.0;
+extern double gKerf;
+extern double gGap;
 using namespace Clipper2Lib;
 
 static std::string trim(const std::string& s) {
@@ -262,26 +262,7 @@ static inline double areaMM2(const Paths64& p)
     return std::abs(Area(p)) / (SCALE * SCALE);
 }
 
-// Test for polygon overlap
-bool overlap(const Paths64& a, const Paths64& b) {
-    double delta = (gKerf * 0.5 + gGap) * SCALE;
-    Paths64 ea = InflatePaths(a, delta, JoinType::Miter, EndType::Polygon);
-    Paths64 eb = InflatePaths(b, delta, JoinType::Miter, EndType::Polygon);
-    Paths64 ua = Union(ea, FillRule::NonZero);
-    Paths64 ub = Union(eb, FillRule::NonZero);
-    Paths64 isect = Intersect(ua, ub, FillRule::NonZero);
-    return std::abs(Area(isect)) > 0.0;
-}
-// Translate polygon set by (dx,dy)
-static Paths64 movePaths(const Paths64& src, int64_t dx, int64_t dy){
-    Paths64 out; out.reserve(src.size());
-    for(const auto& path: src){
-        Path64 p; p.reserve(path.size());
-        for(auto pt: path) p.push_back({pt.x + dx, pt.y + dy});
-        out.push_back(std::move(p));
-    }
-    return out;
-}
+#include "geometry.h"
 
 // ───────── DXF mini loader ─────────
 struct RawPart{

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from auto_nest import parse_args
 
@@ -7,3 +8,36 @@ def test_parse_basic():
     args = parse_args(['-s','100x100','part.dxf'])
     assert args.sheet == '100x100'
     assert args.files == ['part.dxf']
+
+def test_parse_flags():
+    argv = ['-s','50x50','--pop','10','--gen','5','--polish','1',
+            '--fill-gaps','file1.dxf']
+    args = parse_args(argv)
+    assert args.sheet == '50x50'
+    assert args.pop == 10
+    assert args.gen == 5
+    assert args.polish == 1
+    assert args.fill_gaps is True
+
+from config_util import load_config
+
+
+def test_invalid_arg():
+    with pytest.raises(SystemExit):
+        parse_args(['--unknown'])
+
+
+def test_load_config_missing(tmp_path):
+    cfg = load_config(tmp_path / 'nope.yaml')
+    assert cfg == {}
+
+
+def test_default_and_override(tmp_path):
+    cfg_path = tmp_path / 'cfg.yaml'
+    cfg_path.write_text('sheet: 50x50\niterations: 2')
+    args = parse_args(['-s','100x100','part.dxf','--config',str(cfg_path)])
+    cfg = load_config(cfg_path)
+    assert cfg['sheet'] == '50x50'
+    assert args.sheet == '100x100'
+
+

--- a/tests/test_overlap.cpp
+++ b/tests/test_overlap.cpp
@@ -1,10 +1,30 @@
-#define NEST_UNIT_TEST
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
-#include "nesting_algorithm.cpp"
+#include "geometry.h"
 
 TEST_CASE("overlap basic") {
     Paths64 square1 = { { {0,0},{10,0},{10,10},{0,10} } };
     Paths64 square2 = { { {5,5},{15,5},{15,15},{5,15} } };
     REQUIRE(overlap(square1, square2) == true);
 }
+
+TEST_CASE("overlap none") {
+    Paths64 a = { { {0,0},{10,0},{10,10},{0,10} } };
+    Paths64 b = { { {20,0},{30,0},{30,10},{20,10} } };
+    REQUIRE_FALSE(overlap(a,b));
+}
+
+TEST_CASE("overlap touch no kerf") {
+    gKerf = 0.0; gGap = 0.0;
+    Paths64 a = { { {0,0},{10,0},{10,10},{0,10} } };
+    Paths64 b = { { {10,0},{20,0},{20,10},{10,10} } };
+    REQUIRE_FALSE(overlap(a,b));
+}
+
+TEST_CASE("overlap touch with kerf") {
+    gKerf = 1.0; gGap = 0.0;
+    Paths64 a = { { {0,0},{10,0},{10,10},{0,10} } };
+    Paths64 b = { { {10,0},{20,0},{20,10},{10,10} } };
+    REQUIRE(overlap(a,b));
+}
+


### PR DESCRIPTION
## Summary
- move overlap and movePaths helpers to new geometry module
- update build files for new geometry library
- expand CLI unit tests
- extend overlap tests to check kerf and no-touch cases

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/test_overlap`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68882fba1050832a9d1b5b2e008a7232