### PR TITLE
Remove config file usage

### DIFF
--- a/auto_nest.py
+++ b/auto_nest.py
@@ -6,8 +6,6 @@ from multiprocessing import Pool
 from pathlib import Path
 from tqdm import tqdm  # прогресс-бар
 
-from config_util import load_config
-
 sys.stdout.reconfigure(encoding='utf-8')
 
 
@@ -27,7 +25,6 @@ def parse_args(argv=None):
     parser.add_argument("--runs", type=int)
     parser.add_argument("-n", "--num", nargs="*")
     parser.add_argument("--fill-gaps", action="store_true")
-    parser.add_argument("--config", default="config.yaml")
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-j", "--join-segments", action="store_true")
     parser.add_argument("--pop", type=int)
@@ -39,39 +36,31 @@ def parse_args(argv=None):
 
 def main(argv=None):
     args = parse_args(argv)
-    cfg = load_config(args.config)
-
-    sheet = args.sheet or cfg.get("sheet")
+    sheet = args.sheet
     if not sheet or len(args.files) == 0:
         print("usage: auto_nest.py -s WxH part1.dxf[:N] ...")
         return 1
 
-    iterations = args.iterations if args.iterations is not None else cfg.get("iterations", 1)
-    strategies = [args.strategy] if args.strategy else [cfg.get("strategy", "area")]
-    runs = args.runs if args.runs is not None else cfg.get("runs", 1)
+    iterations = args.iterations if args.iterations is not None else 1
+    strategies = [args.strategy] if args.strategy else ["area"]
+    runs = args.runs if args.runs is not None else 1
     nums = [int(n) for n in (args.num or [])]
 
     nest_flags = []
-    if args.verbose or cfg.get("verbose"):
+    if args.verbose:
         nest_flags.append("-v")
-    if args.join_segments or cfg.get("join_segments"):
+    if args.join_segments:
         nest_flags.append("-j")
-    if args.fill_gaps or cfg.get("fill_gaps"):
+    if args.fill_gaps:
         nest_flags.append("--fill-gaps")
     if args.pop is not None:
         nest_flags += ["--pop", str(args.pop)]
-    elif cfg.get("pop_size"):
-        nest_flags += ["--pop", str(cfg.get("pop_size"))]
     if args.gen is not None:
         nest_flags += ["--gen", str(args.gen)]
-    elif cfg.get("generations"):
-        nest_flags += ["--gen", str(cfg.get("generations"))]
     if args.rot is not None:
         nest_flags += ["--rot", str(args.rot)]
-    elif cfg.get("rot"):
-        nest_flags += ["--rot", str(cfg.get("rot"))]
-    if args.polish is not None or cfg.get("polish"):
-        polish = args.polish if args.polish is not None else cfg.get("polish")
+    if args.polish is not None:
+        polish = args.polish
         nest_flags += ["--polish", str(polish)]
 
     dxf_files = []

--- a/config_util.py
+++ b/config_util.py
@@ -1,11 +1,13 @@
-import yaml
-from pathlib import Path
+"""Placeholder utilities for configuration handling.
 
-DEFAULT_CONFIG = Path('config.JSON')
+This project no longer reads configuration files. ``load_config`` is kept
+for compatibility but always returns an empty dictionary.
+"""
 
-def load_config(path=None):
-    path = Path(path or DEFAULT_CONFIG)
-    if path.exists():
-        with open(path, 'r', encoding='utf-8') as f:
-            return yaml.safe_load(f) or {}
+
+def load_config(_=None):
+    """Return an empty configuration dict.
+
+    Parameters are ignored because loading from files is not supported.
+    """
     return {}

--- a/extract_all_shapes.py
+++ b/extract_all_shapes.py
@@ -4,7 +4,6 @@ import math
 import sys
 import ezdxf
 from ezdxf.units import InsertUnits, conversion_factor
-from config_util import load_config
 
 def dist(p, q):
     return math.hypot(p[0] - q[0], p[1] - q[1])
@@ -159,13 +158,11 @@ def parse_args(argv=None):
     parser.add_argument("input")
     parser.add_argument("output")
     parser.add_argument("repeat", nargs="?", default="repeat=1")
-    parser.add_argument("--config", default="config.yaml")
     return parser.parse_args(argv)
 
 
 def main(argv=None):
     args = parse_args(argv)
-    cfg = load_config(args.config)
     in_dxf = args.input
     out_json = args.output
     repeat = 1
@@ -175,7 +172,7 @@ def main(argv=None):
         except Exception:
             print("Invalid repeat argument, must be repeat=N")
             return 1
-    tol = cfg.get("tolerance", 0.05)
+    tol = 0.05
     details = extract_all_details(in_dxf, tol=tol)
     if repeat > 1:
         details = details * repeat

--- a/pdf_report.py
+++ b/pdf_report.py
@@ -7,7 +7,6 @@ from reportlab.lib.utils import ImageReader
 import matplotlib.pyplot as plt
 import ezdxf
 import io
-from config_util import load_config
 
 def _plot_layout(dxf_file, fill, waste):
     doc = ezdxf.readfile(dxf_file)
@@ -74,14 +73,12 @@ def parse_args(argv=None):
     parser.add_argument('csv')
     parser.add_argument('pdf')
     parser.add_argument('--dxf', default=None)
-    parser.add_argument('--config', default='config.yaml')
     return parser.parse_args(argv)
 
 
 def main(argv=None):
     args = parse_args(argv)
-    cfg = load_config(args.config)
-    dxf_file = args.dxf or cfg.get('layout_dxf')
+    dxf_file = args.dxf
     generate_report(args.csv, args.pdf, dxf_file)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,12 +32,10 @@ def test_load_config_missing(tmp_path):
     assert cfg == {}
 
 
-def test_default_and_override(tmp_path):
+def test_load_config_ignored(tmp_path):
     cfg_path = tmp_path / 'cfg.yaml'
     cfg_path.write_text('sheet: 50x50\niterations: 2')
-    args = parse_args(['-s','100x100','part.dxf','--config',str(cfg_path)])
     cfg = load_config(cfg_path)
-    assert cfg['sheet'] == '50x50'
-    assert args.sheet == '100x100'
+    assert cfg == {}
 
 


### PR DESCRIPTION
## Summary
- drop any config.yaml/json parsing from the Python tools
- keep `load_config` function but make it a simple stub that returns `{}`
- update CLI utilities to rely purely on command line values
- adjust unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0dc75c5c832ab5ef6e43245dfb5b