### PR TITLE
Add validation and GPU safety checks with debug logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(clipper3 PUBLIC clipper3)
 
 # --- GEOMETRY LIBRARY ---
 add_library(geometry geometry.cpp)
-target_include_directories(geometry PUBLIC . clipper3)
+target_include_directories(geometry PUBLIC . clipper3 spdlog/include)
 target_link_libraries(geometry PUBLIC clipper3)
 
 # --- CUDA (OPTIONAL) ---

--- a/nfp_gpu.cu
+++ b/nfp_gpu.cu
@@ -55,6 +55,10 @@ void minkowskiKernelLauncher(const long long* ax,const long long* ay,
                              const long long* bx,const long long* by,
                              const GPUPair* pairs,int pairCount,
                              long long* outx,long long* outy){
+    if(pairCount <= 0){
+        fprintf(stderr, "[WARN] minkowskiKernelLauncher called with pairCount=%d\n", pairCount);
+        return;
+    }
     FATAL_KERNEL_NULL(ax); FATAL_KERNEL_NULL(ay); FATAL_KERNEL_NULL(bx);
     FATAL_KERNEL_NULL(by); FATAL_KERNEL_NULL(pairs); FATAL_KERNEL_NULL(outx);
     FATAL_KERNEL_NULL(outy);

--- a/overlap_gpu.cu
+++ b/overlap_gpu.cu
@@ -258,7 +258,11 @@ extern "C" {
 
 void overlapKernelLauncher(const long long* d_xs,const long long* d_ys,
                            const GPUPath* d_paths,GPUShape d_cand,
-                           const GPUShape* d_shapes,int n, const size_t* d_offset, int* d_out){
+                           const GPUShape* d_shapes,int n, int* d_out){
+    if(n <= 0){
+        fprintf(stderr, "[WARN] overlapKernelLauncher called with n=%d\n", n);
+        return;
+    }
     // bring shapes and paths back to host to compute prefix sums
     printf("[launcher] d_xs=%p d_ys=%p d_paths=%p d_shapes=%p d_out=%p n=%d\n",
            d_xs, d_ys, d_paths, d_shapes, d_out, n);


### PR DESCRIPTION
## Summary
- validate JSON inputs with detailed logging and skip malformed coordinates
- add spdlog progress messages for loading, greedy, GA and export stages
- improve GPU helpers with sanity checks and fix overlap kernel signature mismatch
- expose spdlog headers to geometry library

## Testing
- `cmake -S . -B build2` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT.)*
- `cmake --build build2 --target nest -j2` *(fails: misleading-indentation and unused-parameter -Werror build failures)*

------
https://chatgpt.com/codex/tasks/task_e_68949c0da140832a9ed2c98a2c47479b