### PR TITLE
Refactor GPU structs into shared header

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -162,10 +162,7 @@ bool overlapBVH(const std::vector<BVHNode>& treeA, const Paths64& pa,
 }
 
 #ifdef USE_CUDA
-struct GPUPath { int start; int size; };
-struct GPUShape { int start; int size; };
-extern "C" void overlapKernelLauncher(const long long* d_xs, const long long* d_ys, const GPUPath* d_paths,
-                                      GPUShape d_cand, const GPUShape* d_shapes, int n, int* d_out);
+#include "geometry_gpu.h"
 #endif
 
 bool cuda_available(){

--- a/geometry_gpu.h
+++ b/geometry_gpu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+struct GPUPath {
+    int start;
+    int size;
+};
+
+struct GPUShape {
+    int start;
+    int size;
+};
+
+static_assert(sizeof(GPUPath) == 8 && alignof(GPUPath) == 4, "GPUPath layout mismatch");
+static_assert(sizeof(GPUShape) == 8 && alignof(GPUShape) == 4, "GPUShape layout mismatch");
+
+extern "C" void overlapKernelLauncher(const long long*, const long long*, const GPUPath*, GPUShape, const GPUShape*, int, int*);
+

--- a/nfp_gpu.cu
+++ b/nfp_gpu.cu
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "geometry.h"
+#include "geometry_gpu.h"
 #include <cstdio>
 #include <cstdlib>
 
@@ -25,7 +26,6 @@
         }                                                                   \
     } while(0)
 
-struct GPUPath { int start; int size; };
 struct GPUPair { GPUPath a; GPUPath b; int start; };
 
 __global__ void minkowskiPairsKernel(const long long* ax,const long long* ay,

--- a/overlap_gpu.cu
+++ b/overlap_gpu.cu
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <cstdlib>
 #include "geometry.h"
+#include "geometry_gpu.h"
 #define DEBUG_LIMIT 20
 
 #define ASSERT_MSG(cond, msg) do { \
@@ -58,8 +59,6 @@
 // ---------------------------------------------------------------------------------
 // Simple geometry structures used on GPU
 // ---------------------------------------------------------------------------------
-struct GPUPath { int start; int size; };
-struct GPUShape { int start; int size; };
 struct Pt { long long x; long long y; };
 
 // ---------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Consolidated GPUPath and GPUShape definitions into new `geometry_gpu.h` with layout static_asserts and kernel launcher declaration.
- Included shared header in CUDA and C++ sources to avoid signature and alignment mismatch.
- Removed duplicate struct declarations from `geometry.cpp`, `nfp_gpu.cu`, and `overlap_gpu.cu`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68958068e7ec832a9e94fb7026deae43